### PR TITLE
Add hover zoom and lightbox for gallery images

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -35,7 +35,12 @@ section{ padding: 56px 0; }
 /* Gallery */
 .gallery{ background:#22302a; color:#e7ece8; }
 .grid-photos{ display:grid; grid-template-columns: repeat(auto-fit, minmax(240px,1fr)); gap:12px; }
-.grid-photos img{ width:100%; height:230px; object-fit:cover; display:block; border-radius:12px; }
+.grid-photos img{ width:100%; height:230px; object-fit:cover; display:block; border-radius:12px; transition:transform .2s ease; cursor:pointer; }
+.grid-photos img:hover{ transform:scale(1.05); }
+
+.lightbox{ position:fixed; inset:0; background:rgba(0,0,0,.6); backdrop-filter:blur(4px); display:flex; align-items:center; justify-content:center; z-index:1000; }
+.lightbox.hidden{ display:none; }
+.lightbox img{ max-width:90vw; max-height:90vh; border-radius:12px; }
 
 /* Amenities */
 .amenities{ background:#f6f7f5; }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -55,11 +55,32 @@
       });
     });
 
-    // 5) Track gallery image clicks by filename
+    // 5) Lightbox for gallery images & track clicks
+    const lightbox = document.getElementById("lightbox");
+    const closeLightbox = () => {
+      if (!lightbox) return;
+      lightbox.classList.add("hidden");
+      lightbox.innerHTML = "";
+      document.body.style.overflow = "";
+    };
+    if (lightbox) {
+      lightbox.addEventListener("click", (e) => {
+        if (e.target === lightbox) closeLightbox();
+      });
+    }
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") closeLightbox();
+    });
+
     document.querySelectorAll("#gallery .grid-photos img").forEach((img) => {
       img.addEventListener("click", () => {
         const file = (img.currentSrc || img.src || "").split("/").pop() || "";
         track("gallery_click", { image: file.toLowerCase() });
+        if (lightbox) {
+          lightbox.innerHTML = `<img src="${img.currentSrc || img.src}" alt="${img.alt}">`;
+          lightbox.classList.remove("hidden");
+          document.body.style.overflow = "hidden";
+        }
       });
     });
   });

--- a/index.html
+++ b/index.html
@@ -113,6 +113,7 @@
 </main>
 
 
+  <div id="lightbox" class="lightbox hidden" role="dialog" aria-modal="true"></div>
 
   <footer>
     <p>&copy; <span id="year"></span> The Rambler’s Rest · Pigeon Forge, TN</p>


### PR DESCRIPTION
## Summary
- Scale gallery thumbnails slightly on hover
- Open clicked gallery images in a fullscreen lightbox with blurred backdrop

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ea860688832fb465ce62a2380a44